### PR TITLE
Fix 3DS Check Version Type

### DIFF
--- a/merchant/1.0/types_order.go
+++ b/merchant/1.0/types_order.go
@@ -376,7 +376,7 @@ type ChecksThreeDs struct {
 	//The result of 3D Secure check.
 	State string `json:"state"`
 	// The 3D Secure version.
-	Version string `json:"version"`
+	Version int `json:"version"`
 }
 
 type Checks struct {


### PR DESCRIPTION
This pull request addresses an issue with the 3DS check version type. According to the [Revolut Merchant API documentation](https://developer.revolut.com/docs/merchant/retrieve-order), the version type for the 3DS check should be an integer, not a string. This update ensures that the version type is correctly implemented as an integer, aligning with the documented API specifications.

Please review the changes and let me know if there are any further adjustments needed.